### PR TITLE
Nix fixes

### DIFF
--- a/doc/source/Nix_Build.rst
+++ b/doc/source/Nix_Build.rst
@@ -3,7 +3,7 @@ Building with Nix
 
 The easiest way to build Simula is to install `nix` and run::
 
-    stack --nix build
+    stack --nix build --ghc-options="-pgmcg++ -pgmlg++"
     source ./swrast.sh # only needs to be run once
 
 Nix automatically downloads every non-Haskell dependency for this project and places them in */nix/store* in such a way that they don't conflict with your current distro's libraries. Running *stack* with these flags tells it how to find these libraries. The *swrast.sh* script tells nix how to find your system's OpenGL drivers.

--- a/shell.nix
+++ b/shell.nix
@@ -11,10 +11,11 @@ pkgs.haskell.lib.buildStackProject {
                              dbus
                              (callPackage simula-wayland/weston2.nix { })
                              (callPackage simula-osvr/OSVR-Core.nix { })
-                             # (callPackage simula-osvr/OSVR-Vive.nix { })
+                             (callPackage simula-openvr/openvr.nix { })
                              libxml2
                              libxkbcommon
                           ];
+
   LANG = "en_US.UTF-8";
   TMPDIR = "/tmp";
 }

--- a/simula-osvr/OSVR-Core.nix
+++ b/simula-osvr/OSVR-Core.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   src = fetchgit {
     url       = "https://github.com/OSVR/OSVR-Core.git";
     rev       = "95655d3174851670b85e9be8e8620ba28f9872f4";
-    sha256    = "16sbfv4fxcvxqhm81in8lkvjpfbiz312kh7pm4vipj7dja1fchy8";
+    sha256    = "0y3lfagv3h2i9fd4py2fpfixcfpa3ad3gzdpj3wxcl7jlrxznvs4";
     deepClone = true; # git clone --recursive
   };
 }


### PR DESCRIPTION
Makes the build work from a clean system with no need to build your own versions of the dependencies. I kept hanging up on OpenVR stuff. This still leaves the nixOS in a state where the `simulavr` binary cannot find `libxkbcommon.so.0` when you run `stack exec simulavr` which never worked for me yet with the nix build.