### PR TITLE
Fix error from usage of non-existing bool type in C

### DIFF
--- a/simula-wayland/cbits/stub.c
+++ b/simula-wayland/cbits/stub.c
@@ -1,5 +1,6 @@
 #define static
 #define inline
+#include "stdbool.h"
 #include "wayland-server.h"
 #include "motorcar-server-protocol.h"
 #include "windowed-output-api.h"


### PR DESCRIPTION
I'm not certain if this is the best solution, so any feedback is welcome. It also doesn't make the project build successfully with Nix, but at least it fixes [#22](https://github.com/SimulaVR/Simula/issues/22).