### PR TITLE
Fix building with Nix

### DIFF
--- a/NixHelpers.sh
+++ b/NixHelpers.sh
@@ -46,7 +46,7 @@ upgradeStack() {
 buildSimulaOnNix() {
   addViveUdevRules
   make init
-  stack --nix build --ghc-options="-pgmc++ -pgmlg++"
+  stack --nix build
   source ./swrast.sh
   echo "Remember to open steam and install and run SteamVR before launching Simula."
 }

--- a/simula-wayland/simula-wayland.cabal
+++ b/simula-wayland/simula-wayland.cabal
@@ -15,6 +15,7 @@ library
       cbits/motorcar-wayland-extensions.c
       cbits/stub.c
       cbits/util.c      
+      cbits/xwayland.c      
   build-depends:
       base >= 4.9 && < 5
     , containers


### PR DESCRIPTION
With this I can now build on NixOS with `NIXPKGS_ALLOW_UNFREE=1 stack --nix build`. Unfortunately I am unable to verify that it runs properly without OpenVR running.