### PR TITLE
Work-around for c2hs being broken

### DIFF
--- a/simula-wayland/shell.nix
+++ b/simula-wayland/shell.nix
@@ -8,6 +8,7 @@ pkgs.haskell.lib.buildStackProject {
                              wayland-protocols
                              wayland
                              xorg.libX11
+                             libxkbcommon
                             (callPackage ./weston3.nix { })
                           ];
   LANG = "en_US.UTF-8";

--- a/simula-wayland/simula-wayland.cabal
+++ b/simula-wayland/simula-wayland.cabal
@@ -24,6 +24,8 @@ library
     , unix
   build-tools:
       c2hs
+  cpp-options:
+      "-D_BITS_FLOATN_H"
   exposed-modules:
       Simula.WaylandServer
       Simula.MotorcarServer


### PR DESCRIPTION
By excluding the problematic header simula-wayland can now be build with Nix. This temporarily solves #17 