### PR TITLE
Fix NixOS detection in DriverCheck.sh

### DIFF
--- a/utils/DriverCheck.sh
+++ b/utils/DriverCheck.sh
@@ -1,4 +1,3 @@
-RUNNING_NIXOS=$(nixos-version > /dev/null 2>&1)
 NVIDIA_VERSION=$(nvidia-smi | grep -ho "Driver Version: [0-9]*.[0-9]*" |  awk '{print $NF}')
 
 getNvidiaHash() {
@@ -51,7 +50,7 @@ getNvidiaHash() {
     esac
 }
 
-if [ ! -z "$RUNNING_NIXOS" ]; then
+if [ -e /etc/NIXOS ]; then
    echo "nixos"
 elif [ -z $NVIDIA_VERSION ]; then
    echo "intel"


### PR DESCRIPTION
`$(nixos-version > /dev/null 2>&1)` will always be empty.  A better way to check if we are running on nixos is just to look for the `/etc/NIXOS` file, which is created during nixos installation:
https://github.com/NixOS/nixpkgs/blob/7e07846d99bed4bd7272b1626038e77a78aa36f6/nixos/modules/installer/tools/nixos-install.sh#L135

This was the cause of my issues in the later comments in https://github.com/SimulaVR/Simula/issues/108