### PR TITLE
Download verbosity

### DIFF
--- a/utils/Helpers.sh
+++ b/utils/Helpers.sh
@@ -202,6 +202,7 @@ installSimula() {
     checkInstallCachix
     cachix use simula
     curl https://www.wolframcloud.com/obj/george.w.singer/installMessage
+    echo "Downloading nixpkgs, this will take a while."
     if [ -z $1 ]; then
       NIXPKGS_ALLOW_UNFREE=1 nix-build -Q default.nix --arg onNixOS "$(checkIfNixOS)" --arg devBuild "false"
       switchToNix


### PR DESCRIPTION
One-line fix that prevents users from going insane about presumably "hanging" software that is in fact not hanging but just downloading very slowly without indication. I am honestly confused why this isn't a feature yet.