### PR TITLE
Delete onNixOS attribute

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
-{ onNixOS, devBuild, profileBuild ? false }:
+{ devBuild, profileBuild ? false }:
 let
     pkgs = if profileBuild then (import ./pinned-nixpkgs.nix { overlays = (import ./nix/profileOverlays.nix); }) else (import ./pinned-nixpkgs.nix { });
 in
-pkgs.callPackage ./Simula.nix { onNixOS = onNixOS; devBuild = devBuild; profileBuild = profileBuild; pkgs = pkgs; }
+pkgs.callPackage ./Simula.nix { devBuild = devBuild; profileBuild = profileBuild; pkgs = pkgs; }


### PR DESCRIPTION
- #208 

`onNixOS` dusturbs creating `flake.nix`, because `pkgs.callPackage ./. { };` is almost used in `flake.nix`, as:
```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
    flake-parts.url = "github:hercules-ci/flake-parts";
  };

  outputs =
    inputs:
    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
      systems = [
        "x86_64-linux"
        "aarch64-linux"
      ];

      perSystem = { pkgs, ... }:
        let
          simila = pkgs.callPackage ./. { };
        in
        {
          packages = {
            inherit simula;
          };

          checks = {
            inherit simula;
          };
        };
    };
}
```

---

I think that Simula must run on the machine installed Nix with same code, so `onNixOS` must be deleted. Also, I think `devBuild` must be deleted by this reasons.