### PR TITLE
Delete i3status submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,9 +35,6 @@
 [submodule "nix/libleak"]
 	path = nix/libleak
 	url = https://github.com/SimulaVR/libleak
-[submodule "submodules/i3status"]
-	path = submodules/i3status
-	url = https://github.com/SimulaVR/i3status
 [submodule "submodules/monado"]
 	path = submodules/monado
 	url = https://github.com/SimulaVR/monado-xv.git

--- a/Simula.nix
+++ b/Simula.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchFromGitHub, haskellPackages, callPackage, buildEnv, xrdb, wmctrl, SDL2, lib, onNixOS ? false, xwayland, xkbcomp, ghc, ffmpeg-full, midori, xfce, devBuild, fontconfig, glibcLocales, dejavu_fonts, writeScriptBin, coreutils, curl, vulkan-loader, mimic, xsel, xclip, dialog, synapse, openxr-loader, xpra, valgrind, xorg, writeShellScriptBin, python3, awscli, wayland, wayland-protocols, zstd, profileBuild ? false, pkgs, patchelf, libv4l, openssl, cabal-install, externalSrc ? null}:
+{ stdenv, fetchFromGitHub, haskellPackages, callPackage, buildEnv, xrdb, wmctrl, SDL2, lib, onNixOS ? false, xwayland, xkbcomp, ghc, ffmpeg-full, midori, xfce, devBuild, fontconfig, glibcLocales, dejavu_fonts, writeScriptBin, coreutils, curl, vulkan-loader, mimic, xsel, xclip, dialog, synapse, openxr-loader, xpra, valgrind, xorg, writeShellScriptBin, python3, awscli, wayland, wayland-protocols, zstd, profileBuild ? false, pkgs, patchelf, libv4l, openssl, cabal-install, externalSrc ? null, i3status ? callPackage (fetchFromGitHub { owner = "SimulaVR"; repo = "i3status"; rev = "fba8ea459ce4da2e3198f7d536569668c3d0b9b9"; hash = "sha256-vLUDeYwbzuCdYsdb082jcsjTj3rpOTJK06H0WNrfI0U="; }) { } }:
 let
 
      localSrc = fetchGit {
@@ -45,8 +45,6 @@ let
     monado = callPackage ./submodules/monado/monado.nix { gst-plugins-base = pkgs.gst_all_1.gst-plugins-base; gstreamer = pkgs.gst_all_1.gstreamer; };
 
     ghc-version = ghc.version;
-
-    i3status = callPackage ./submodules/i3status/i3status.nix {};
 
     devBuildFalse = ''
       ln -s ${godot}/bin/godot.x11.opt.debug.64 $out/bin/godot.x11.opt.debug.64


### PR DESCRIPTION
- #211
> This PR saves `i3status` submodule.

# Why did I created this PR

Since before, I have thought that it is bad trend to use Git submodules, because Git submodules is difficult to manage cleanly, and it can be replaced by Nix fetcher. This means that we can reduce amount of code in SimulaVR/Simula repo.

However, This PR creates difficulty of building Simula by other tools, because of deletion local code in SimulaVR/Simula.

## Changes

- Delete `/submodules/i3status`
- Move `i3status` definition in `Simula.nix`, to attribute set of `Simula.nix`'s argument