### PR TITLE
fix(flake.nix): Fix shellscript

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,8 @@
   description = "Flake for SimulaVR/Simula";
 
   nixConfig = {
-    extra-substituters = [
-      "https://simula.cachix.org"
-    ];
-    extra-trusted-public-keys = [
-      "simula.cachix.org-1:Sr0SD5FIjc8cUVIeBHl8VJswQEJOBIE6u3wpmjslGBA="
-    ];
+    extra-substituters = [ "https://simula.cachix.org" ];
+    extra-trusted-public-keys = [ "simula.cachix.org-1:Sr0SD5FIjc8cUVIeBHl8VJswQEJOBIE6u3wpmjslGBA=" ];
   };
 
   inputs = {
@@ -329,7 +325,7 @@
               makeWrapper $out/bin/simula-unwrapped $out/bin/simula \
               --prefix PATH : ${lib.makeBinPath passthru.simulaRuntimePrograms} \
               --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath passthru.simulaRuntimeLibs}
-              
+
               cat > $out/bin/simula-monado-service << 'EOF'
                 ${simulaMonadoServiceContent}
               EOF
@@ -358,11 +354,7 @@
           };
 
           packages = {
-            inherit
-              simula
-              godot-haskell
-              godot-haskell-plugin
-              ;
+            inherit simula godot-haskell godot-haskell-plugin;
             default = simula;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -208,6 +208,11 @@
             echo "SIMULA_LOG_DIR: $SIMULA_LOG_DIR"
             echo "SIMULA_DATA_DIR: $SIMULA_DATA_DIR"
             echo "SIMULA_CONFIG_DIR: $SIMULA_CONFIG_DIR"
+
+            # Creates directories for SIMULA_*_DIR
+            mkdir -p "$SIMULA_LOG_DIR"
+            mkdir -p "$SIMULA_DATA_DIR"
+            mkdir -p "$SIMULA_CONFIG_DIR"
           '';
 
           # Needed to ensure fonts don't show up as blocks on certain non-NixOS distributions, IIRC
@@ -218,15 +223,15 @@
           copySimulaConfigFiles = ''
             # Copy over default config files if they don't already exist
             if [ ! -f "$SIMULA_CONFIG_DIR/HUD.config" ]; then
-              cp "$SIMULA_NIX_DIR/config/HUD.config" "$SIMULA_CONFIG_DIR/HUD.config"
+              cp "$SIMULA_NIX_DIR/opt/simula/config/HUD.config" "$SIMULA_CONFIG_DIR/HUD.config"
             fi
 
             if [ ! -f "$SIMULA_CONFIG_DIR/config.dhall" ]; then
-              cp "$SIMULA_NIX_DIR/config/config.dhall" "$SIMULA_CONFIG_DIR/config.dhall"
+              cp "$SIMULA_NIX_DIR/opt/simula/config/config.dhall" "$SIMULA_CONFIG_DIR/config.dhall"
             fi
 
             if [ ! -d "$SIMULA_DATA_DIR/environments" ]; then
-              cp -R "$SIMULA_NIX_DIR/environments" "$SIMULA_DATA_DIR/environments"
+              cp -R "$SIMULA_NIX_DIR/opt/simula/environments" "$SIMULA_DATA_DIR/environments"
             fi
           '';
 


### PR DESCRIPTION
This PR fixes the following problem by editing `simula-unwrapped` in `/flake.nix`.

# The problem

An error occurred on 19edac45690a31c6255481ab08ebf16799a46513, when I run Simula on my device. The reason is that there are no directories for `$SIMULA_LOG_DIR`, `$SIMULA_DATA_DIR` and `$SIMULA_CONFIG_DIR`.

The log when I run Simula on my device:
```txt
$ ./result/bin/simula
XDG_CACHE_HOME: /home/haruki/.cache
XDG_DATA_HOME: /home/haruki/.local/share
XDG_CONFIG_HOME: /home/haruki/.config
SIMULA_NIX_DIR: /nix/store/w58nxwwsn97469n480pcw0v4wz833wf2-simula-0.0.0
SIMULA_LOG_DIR: /home/haruki/.cache/Simula
SIMULA_DATA_DIR: /home/haruki/.local/share/Simula
SIMULA_CONFIG_DIR: /home/haruki/.config/Simula
cp: cannot stat '/nix/store/w58nxwwsn97469n480pcw0v4wz833wf2-simula-0.0.0/config/HUD.config': No such file or directory
```

# How to resolve it

- Edited `xdgAndSimulaEnvVars` in `flake.nix` to create below directories.
  1. `$SIMULA_LOG_DIR`
  2. `$SIMULA_DATA_DIR`
  3. `$SIMULA_CONFIG_DIR`
- Edited `copySimulaConfigFiles` in `flake.nix` to copy correct config/asset files