### PR TITLE
feat(nixosModules): Create .#nixosModules.simula

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,34 @@
 
         imports = [ inputs.treefmt-nix.flakeModule ];
 
+
+        flake.nixosModules = rec {
+          default = simula;
+          simula = moduleWithSystem (
+            perSystem@{ config }:
+            nixos@{ config, lib, ... }:
+
+            let
+              cfg = config.programs.simula;
+            in
+
+            {
+              options.programs.simula = {
+                enable = lib.options.mkEnableOption "Linux VR Desktop";
+                package = lib.options.mkOption {
+                  type = lib.types.package;
+                  default = perSystem.config.packages.simula;
+                };
+                extraPackages = lib.options.mkOption {
+                  type = lib.types.listOf lib.types.package;
+                  default = [ ];
+                };
+              };
+              config = lib.mkIf cfg.enable { environment.systemPackages = [ cfg.package ] ++ cfg.extraPackages; };
+            }
+          );
+        };
+
         perSystem =
           {
             config,
@@ -711,7 +739,6 @@ _EOF_HELP_
                 platforms = lib.platforms.linux;
               };
             };
-
           in
           {
             _module.args.pkgs = import inputs.nixpkgs {


### PR DESCRIPTION
# Purpose

This PR adds Nix flake attribute `.#nixosModules` for Nix flakes' users.

# How to use `.#nixosModules`

```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";

    # Now there is my fork repo
    simula.url = "github:haruki7049/Simula/add-nixos-modules";
    # simula.url = "github:SimulaVR/Simula";
  };

  outputs = { nixpkgs, simula, ... }: {
    nixosConfigurations."example-configuration" = nixpkgs.lib.nixosSystem {
      system = "x86_64-linux";
      modules = [
        ({
          config,
            lib,
            pkgs,
            ...
        }: {
          # Omitting other configuration, such as imports, boot, networking, and etc...
          programs.simula.enable = true;
        })
      ];
    };
  };
}
```

# Out of scope

1. This PR doesn't creates any Nix channels, so we cannot use a channel for Simula, as `<simula/modules>`.