### PR TITLE
Ubuntu dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -384,11 +384,17 @@
                 pkgs.inotify-tools
                 pkgs.cabal-install
                 pkgs.haskellPackages.ghc
+                pkgs.patchelf
+                pkgs.pkg-config
               ];
 
               buildInputs = [
                 haskell-dependencies
                 pkgs.zlib
+                pkgs.zlib.dev
+                pkgs.zstd
+                pkgs.xz
+                pkgs.bzip2
               ];
 
               LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;

--- a/utils/Helpers.sh
+++ b/utils/Helpers.sh
@@ -16,11 +16,11 @@ updateEmail() {
 # wlroots in the nix store
 patchGodotWlroots(){
     PATH_TO_SIMULA_WLROOTS="`pwd`/submodules/wlroots/build/"
-    OLD_RPATH="`./result/bin/patchelf --print-rpath submodules/godot/bin/godot.x11.tools.64`"
+    OLD_RPATH="`patchelf --print-rpath submodules/godot/bin/godot.x11.tools.64`"
     if [[ $OLD_RPATH != $PATH_TO_SIMULA_WLROOTS* ]]; then # Check if the current RPATH contains our local simula wlroots build. If not, patchelf it to add it
         echo "Patching godot.x11.tools to point to local wlroots lib"
         echo "Changing path to: $PATH_TO_SIMULA_WLROOTS:$OLD_RPATH"
-        ./result/bin/patchelf --set-rpath "$PATH_TO_SIMULA_WLROOTS:$OLD_RPATH" submodules/godot/bin/godot.x11.tools.64
+        patchelf --set-rpath "$PATH_TO_SIMULA_WLROOTS:$OLD_RPATH" submodules/godot/bin/godot.x11.tools.64
     else
         echo "Not patching godot.x11.tools, already patched."
     fi


### PR DESCRIPTION
For enabling building Simula with `just build` under ubuntu a few dev libraries need to be added to the nix flake.

I also needed to modify the Helpers.sh so it wouldn't crash on a patchelf it couldn't find in result/bin. I'm not sure if that is is handled correctly for all use cases like on nixOs. But as I understand it this shouldn't affect it too much and it should behave the same.